### PR TITLE
Initial Commit

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Fortinet - FortiSOAR Integrations
+Copyright (c) 2024 Fortinet - FortiSOAR Integrations
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Fortinet - FortiSOAR Integrations
+Copyright (c) 2025 Fortinet - FortiSOAR Integrations
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+# widget-template-repository

--- a/widget/edit.controller.js
+++ b/widget/edit.controller.js
@@ -1,0 +1,94 @@
+/* Copyright start
+    MIT License
+    Copyright (c) 2025 Fortinet Inc
+Copyright end */
+'use strict';
+(function () {
+  angular
+    .module('cybersponse')
+    .controller('editExportTemplateWizard100Ctrl', editExportTemplateWizard100Ctrl);
+
+  editExportTemplateWizard100Ctrl.$inject = ['$scope', '$uibModalInstance', 'config', 'widgetUtilityService', '$timeout', '$http', 'API'];
+
+  function editExportTemplateWizard100Ctrl($scope, $uibModalInstance, config, widgetUtilityService, $timeout, $http, API) {
+    $scope.cancel = cancel;
+    $scope.save = save;
+    $scope.config = config;
+
+    function _handleTranslations() {
+      let widgetNameVersion = widgetUtilityService.getWidgetNameVersion($scope.$resolve.widget, $scope.$resolve.widgetBasePath);
+      if (widgetNameVersion) {
+        widgetUtilityService.checkTranslationMode(widgetNameVersion).then(function () {
+          $scope.viewWidgetVars = {
+            // Create your translating static string variables here
+            EDIT_VIEW_SELECT_DESCRIPTION: widgetUtilityService.translate('exportTemplateWizard.EDIT_VIEW_SELECT_DESCRIPTION'),
+            EDIT_VIEW_DEFAULT_SELECT_ITEM: widgetUtilityService.translate('exportTemplateWizard.EDIT_VIEW_DEFAULT_SELECT_ITEM'),
+            EDIT_VIEW_SAVE_BTN_LABEL: widgetUtilityService.translate('exportTemplateWizard.EDIT_VIEW_SAVE_BTN_LABEL'),
+            EDIT_VIEW_CLOSE_BTN_LABEL: widgetUtilityService.translate('exportTemplateWizard.EDIT_VIEW_CLOSE_BTN_LABEL')
+          };
+        });
+      } else {
+        $timeout(function () {
+          $scope.cancel();
+        });
+      }
+    }
+
+    function getExportTemplate() {
+      var queryPayload =
+      {
+        "sort": [
+          {
+            "field": "modifyDate",
+            "direction": "DESC"
+          }
+        ],
+        "limit": 30,
+        "logic": "AND",
+        "filters": [
+          {
+            "field": "type",
+            "operator": "neq",
+            "_operator": "neq",
+            "value": "SolutionPack Export",
+            "type": "primitive"
+          }
+        ],
+        "__selectFields": [
+          "name",
+          "lastExportDate",
+          "modifyUser",
+          "portingActions",
+          "@id",
+          "@type",
+          "id"
+        ]
+      };
+      var queryUrl = API.QUERY + 'export_templates?$limit=30';
+      $http.post(queryUrl, queryPayload).then(function (response) {
+        if (response.data['hydra:member'] && response.data['hydra:member'].length > 0) {
+          $scope.config.exportTemplates = response.data['hydra:member'];
+          $scope.templateNames = $scope.config.exportTemplates.map(function (template) {
+            return template.name;
+          });
+        }
+      });
+    }
+
+    function init() {
+      getExportTemplate();
+      _handleTranslations();
+    }
+
+    init();
+
+    function cancel() {
+      $uibModalInstance.dismiss('cancel');
+    }
+
+    function save() {
+      $uibModalInstance.close($scope.config);
+    }
+
+  }
+})();

--- a/widget/edit.html
+++ b/widget/edit.html
@@ -1,0 +1,43 @@
+<!-- Copyright start
+    MIT License
+    Copyright (c) 2025 Fortinet Inc
+Copyright end -->
+<form data-ng-submit="save()" class="noMargin" name="exportTemplateWizardForm"
+    data-ng-class="{'state-wait': processing }" novalidate>
+    <div class="modal-header">
+        <h3 class="modal-title col-md-9">Export Template Wizard Edit View</h3>
+        <button type="button" class="close" data-ng-click="cancel()" data-dismiss="modal" aria-label="Close"
+            id="close-edit-widget-form-btn">
+            <div aria-hidden="true" class="version-button">+</div>
+        </button>
+    </div>
+    <div class="modal-body">
+        <div class="form-group">
+            <div class="padding-20 margin-top-md padding-top-md padding-bottom-md">
+                <p class="font-Size-13 muted">
+                    <span
+                        data-ng-bind-html="'{{viewWidgetVars.EDIT_VIEW_SELECT_DESCRIPTION}}'| domPurifySanitize"></span>
+                </p>
+                <div class="cs-select">
+                    <ui-select name="select_threat_detection_tools" id="select_threat_detection_tools"
+                        data-ng-model="config.selectedExportTemplates" data-ng-required="true" multiple
+                        class="custom-multi-select" append-to-body="false">
+                        <ui-select-match placeholder="{{viewWidgetVars.EDIT_VIEW_DEFAULT_SELECT_ITEM}}">{{$item}}
+                        </ui-select-match>
+                        <ui-select-choices repeat="option in templateNames | filter: $select.search | orderBy: '$value'"
+                            refresh-delay="200" ng-show="($select.items.length > 0) ||">
+                            <div ng-bind-html="option | highlight: $select.search"></div>
+                        </ui-select-choices>
+                    </ui-select>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="modal-footer">
+        <button id="edit-widget-save" type="submit" class="btn btn-sm btn-primary"
+            data-ng-disabled="(config.selectedExportTemplates && config.selectedExportTemplates.length === 0) || (config.selectedExportTemplates === undefined)"><i
+                class="icon icon-check margin-right-sm"></i>{{viewWidgetVars.EDIT_VIEW_SAVE_BTN_LABEL}}</button>
+        <button id="edit-widget-cancel" type="button" class="btn btn-sm btn-default" data-ng-click="cancel()"><i
+                class="icon icon-close margin-right-sm"></i>{{viewWidgetVars.EDIT_VIEW_CLOSE_BTN_LABEL}}</button>
+    </div>
+</form>

--- a/widget/info.json
+++ b/widget/info.json
@@ -1,0 +1,20 @@
+{
+    "name": "exportTemplateWizard",
+    "title": "Export Template Wizard",
+    "subTitle": "To review and configure FortiSOAR export templates that define what content and settings are saved to source control systems like GitHub",
+    "version": "1.0.0",
+    "publishedDate": 1753786928,
+    "releaseNotes": "unavailable",
+    "metadata": {
+        "help_online": "",
+        "description": "To review and configure FortiSOAR export templates that define what content and settings are saved to source control systems like GitHub.",
+        "pages": [
+            "View Panel"
+        ],
+        "certified": "Yes",
+        "publisher": "Fortinet",
+        "compatibility": [
+            "7.5.0"
+        ]
+    }
+}

--- a/widget/info.json
+++ b/widget/info.json
@@ -3,7 +3,7 @@
     "title": "Export Template Wizard",
     "subTitle": "To review and configure FortiSOAR export templates that define what content and settings are saved to source control systems like GitHub",
     "version": "1.0.0",
-    "publishedDate": 1753786928,
+    "published_date": 1753786928,
     "releaseNotes": "unavailable",
     "metadata": {
         "help_online": "",

--- a/widget/view.controller.js
+++ b/widget/view.controller.js
@@ -1,0 +1,67 @@
+/* Copyright start
+    MIT License
+    Copyright (c) 2025 Fortinet Inc
+Copyright end */
+'use strict';
+(function () {
+  angular
+    .module('cybersponse')
+    .controller('exportTemplateWizard100Ctrl', exportTemplateWizard100Ctrl);
+
+  exportTemplateWizard100Ctrl.$inject = ['$scope', 'widgetUtilityService', '$uibModal', '$http', 'API', 'toaster', '_'];
+
+  function exportTemplateWizard100Ctrl($scope, widgetUtilityService, $uibModal, $http, API, toaster, _) {
+    $scope.openWizard = openWizard;
+    $scope.changeTemplate = changeTemplate;
+    $scope.selectedTemplate = null;
+    $scope.isTemplateSelected = false;
+
+    function openWizard() {
+      let templateUuid = $scope.selectedTemplate.uuid;
+      let skipToReview = false;
+      var modal = $uibModal.open({
+        animation: false,
+        component: 'exportWizardComponent',
+        backdrop: 'static',
+        windowClass: 'modal-ingestion',
+        scope: $scope,
+        resolve: {
+          templateUuid: function () {
+            return templateUuid;
+          },
+          skipToReview: function () {
+            return skipToReview;
+          }
+        }
+      });
+      modal.result.finally(function () {
+        $scope.$broadcast('csGrid:refresh');
+        $scope.isTemplateSelected = false;
+        $scope.selectedTemplate = null;
+      });
+    }
+
+    function changeTemplate() {
+      $scope.isTemplateSelected = true;
+    }
+
+    function _handleTranslations() {
+      widgetUtilityService.checkTranslationMode($scope.$parent.model.type).then(function () {
+        $scope.viewWidgetVars = {
+          // Create your translating static string variables here
+          VIEW_DEFAULT_SELECT_ITEM: widgetUtilityService.translate('exportTemplateWizard.VIEW_DEFAULT_SELECT_ITEM'),
+          VIEW_EXPORT_BTN_LABEL: widgetUtilityService.translate('exportTemplateWizard.VIEW_EXPORT_BTN_LABEL')
+        };
+      });
+    }
+
+    function init() {
+      $scope.exportTemplates = _.filter($scope.config.exportTemplates, function (template) {
+        return _.includes($scope.config.selectedExportTemplates, template.name);
+      });
+      _handleTranslations();
+    }
+
+    init();
+  }
+})();

--- a/widget/view.html
+++ b/widget/view.html
@@ -1,0 +1,28 @@
+<!-- Copyright start
+    MIT License
+    Copyright (c) 2025 Fortinet Inc
+Copyright end -->
+<div class="widget widget-container chart">
+    <div class="display-flex-space-between margin-chart">
+        <div class="padding-right-0 padding-left-0 widget-dashboard-title-width"
+            data-ng-class="(page === 'dashboard' || page === 'reporting') ? 'widget-dashboard-title-width' : 'widget-title-width'">
+        </div>
+    </div>
+    <div class="form-group margin-bottom-0">
+        <div class="margin-left-md">
+            <div class="cs-select">
+                <select class="form-control" name="selected-template" id="selected-template" style="max-width: 50%;"
+                    data-ng-options="template.name for template in exportTemplates track by template.uuid"
+                    ng-model="selectedTemplate" ng-change="changeTemplate()" required>
+                    <option value="">{{viewWidgetVars.VIEW_DEFAULT_SELECT_ITEM}}</option>
+                </select>
+            </div>
+            <div class="margin-top-md margin-bottom-xlg">
+                <button type="button" class="btn btn-primary btn-sm" data-ng-click="openWizard()"
+                    data-ng-disabled="(isTemplateSelected===false)" id="dropdown-export"><i
+                        class="icon icon-dashboard-settings margin-right-sm"></i>{{viewWidgetVars.VIEW_EXPORT_BTN_LABEL}}
+                </button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/widget/widgetAssets/js/widgetUtility.service.js
+++ b/widget/widgetAssets/js/widgetUtility.service.js
@@ -1,0 +1,96 @@
+/* Copyright start
+    MIT License
+    Copyright (c) 2025 Fortinet Inc
+Copyright end */
+'use strict';
+
+(function () {
+  angular
+    .module('cybersponse')
+    .factory('widgetUtilityService', widgetUtilityService);
+
+  widgetUtilityService.$inject = ['$q', '$http', '$injector', '$interpolate', 'toaster'];
+
+  function widgetUtilityService($q, $http, $injector, $interpolate, toaster) {
+    var service;
+    var translationServiceExists;
+    var translationService;
+    var translationData;
+    var widgetNameVersion;
+    service = {
+      checkTranslationMode: checkTranslationMode,
+      getWidgetNameVersion: getWidgetNameVersion,
+      translate: translate
+    };
+
+    function getWidgetNameVersion(widget, widgetBasePath) {
+      let widgetNameVersion;
+      if (widget) {
+        widgetNameVersion = widget.name + '-' + widget.version;
+      } else if (widgetBasePath) {
+        let pathData = widgetBasePath.split('/');
+        widgetNameVersion = pathData[pathData.length - 1];
+      } else {
+        toaster.warning({
+          body: 'Preview is unavailable for widgets that support localization.'
+        });
+      }
+      return widgetNameVersion;
+    }
+
+    function checkTranslationMode(widgetName) {
+      widgetNameVersion = widgetName;
+      try {
+        translationService = $injector.get('translationService');
+      } catch (error) {
+        console.log('"translationService" doesn\'t exists');
+      }
+      var defer = $q.defer();
+      translationServiceExists = typeof translationService !== 'undefined';
+      if (!translationServiceExists) {
+        var WIDGET_BASE_PATH;
+        try {
+          WIDGET_BASE_PATH = $injector.get('WIDGET_BASE_PATH');
+        } catch (e) {
+          WIDGET_BASE_PATH = {
+            INSTALLED: 'widgets/installed/'
+          };
+        }
+        $http.get(WIDGET_BASE_PATH.INSTALLED + widgetNameVersion + '/widgetAssets/locales/en.json').then(function (enTranslation) {
+          translationData = enTranslation.data;
+          defer.resolve();
+        }, function (error) {
+          console.log('English translation for widget doesn\'t exists');
+          defer.reject(error);
+        });
+      } else {
+        defer.resolve();
+      }
+      return defer.promise;
+    }
+
+    function translate(KEY, params) {
+      if (translationServiceExists) {
+        return translationService.instantTranslate(KEY, params);
+      } else {
+        var translationValue = angular.copy(translationData);
+        var keys = KEY.split('.');
+
+        for (var i = 0; i < keys.length; i++) {
+          if (translationValue.hasOwnProperty(keys[i])) {
+            translationValue = translationValue[keys[i]];
+          } else {
+            translationValue = '';
+            break;
+          }
+        }
+        if (params) {
+          return $interpolate(translationValue)(params);
+        }
+        return translationValue;
+      }
+    }
+
+    return service;
+  }
+})();

--- a/widget/widgetAssets/locales/en.json
+++ b/widget/widgetAssets/locales/en.json
@@ -1,0 +1,10 @@
+{
+    "exportTemplateWizard": {
+        "EDIT_VIEW_SELECT_DESCRIPTION": "Select one or more export templates to define what system content will be included in the export. \n\nFortiSOAR export templates specify the components—such as modules, reports, dashboards, playbooks, connectors, widgets, and admin/security settings—that will be packaged into a ZIP file.",
+        "EDIT_VIEW_DEFAULT_SELECT_ITEM": "Select Export Templates...",
+        "EDIT_VIEW_SAVE_BTN_LABEL": "Save",
+        "EDIT_VIEW_CLOSE_BTN_LABEL": "Close",
+        "VIEW_DEFAULT_SELECT_ITEM": "Select a Template ...",
+        "VIEW_EXPORT_BTN_LABEL": "Edit Export Template"
+    }
+}

--- a/widget/widgetAssets/locales/ja.json
+++ b/widget/widgetAssets/locales/ja.json
@@ -1,0 +1,10 @@
+{
+    "exportTemplateWizard": {
+        "EDIT_VIEW_SELECT_DESCRIPTION": "1つ以上のエクスポートテンプレートを選択して、エクスポートに含めるシステムコンテンツを定義します。\n\nFortiSOARのエクスポートテンプレートは、モジュール、レポート、ダッシュボード、プレイブック、コネクタ、ウィジェット、管理/セキュリティ設定など、ZIPファイルにパッケージされるコンポーネントを指定します。",
+        "EDIT_VIEW_DEFAULT_SELECT_ITEM": "エクスポートテンプレートを選択...",
+        "EDIT_VIEW_SAVE_BTN_LABEL": "保存",
+        "EDIT_VIEW_CLOSE_BTN_LABEL": "閉じる",
+        "VIEW_DEFAULT_SELECT_ITEM": "テンプレートを選択...",
+        "VIEW_EXPORT_BTN_LABEL": "エクスポートテンプレートを編集"
+    }
+}

--- a/widget/widgetAssets/locales/ko.json
+++ b/widget/widgetAssets/locales/ko.json
@@ -1,0 +1,10 @@
+{
+    "exportTemplateWizard": {
+        "EDIT_VIEW_SELECT_DESCRIPTION": "하나 이상의 내보내기 템플릿을 선택하여 내보내기에 포함할 시스템 콘텐츠를 정의합니다.\n\nFortiSOAR 내보내기 템플릿은 모듈, 보고서, 대시보드, 플레이북, 커넥터, 위젯, 관리자/보안 설정과 같은 구성 요소를 ZIP 파일로 패키징합니다.",
+        "EDIT_VIEW_DEFAULT_SELECT_ITEM": "내보내기 템플릿 선택...",
+        "EDIT_VIEW_SAVE_BTN_LABEL": "저장",
+        "EDIT_VIEW_CLOSE_BTN_LABEL": "닫기",
+        "VIEW_DEFAULT_SELECT_ITEM": "템플릿 선택...",
+        "VIEW_EXPORT_BTN_LABEL": "내보내기 템플릿 편집"
+    }
+}

--- a/widget/widgetAssets/locales/zh_cn.json
+++ b/widget/widgetAssets/locales/zh_cn.json
@@ -1,0 +1,10 @@
+{
+    "exportTemplateWizard": {
+        "EDIT_VIEW_SELECT_DESCRIPTION": "选择一个或多个导出模板，以定义导出中包含的系统内容。\n\nFortiSOAR 导出模板指定将打包到 ZIP 文件中的组件，如模块、报告、仪表板、剧本、连接器、小部件和管理/安全设置。",
+        "EDIT_VIEW_DEFAULT_SELECT_ITEM": "选择导出模板...",
+        "EDIT_VIEW_SAVE_BTN_LABEL": "保存",
+        "EDIT_VIEW_CLOSE_BTN_LABEL": "关闭",
+        "VIEW_DEFAULT_SELECT_ITEM": "选择模板...",
+        "VIEW_EXPORT_BTN_LABEL": "编辑导出模板"
+    }
+}


### PR DESCRIPTION
<span data-teams="true"><p>To <strong>review and configure FortiSOAR export templates</strong> that define <strong>what content and settings</strong> are saved to source control systems like GitHub.<br>
This helps control versioning, collaboration, and CI/CD integration by ensuring only relevant content is exported and tracked.</p><hr><h2><strong>Requirements This Widget Fulfills</strong></h2><p>&nbsp;</p>
Requirement | How It’s Fulfilled
-- | --
Allow users to view and manage export templates | Templates are listed and can be opened for editing
Enable customization of what content/settings are versioned | Users can include/exclude playbooks, modules, connectors, etc.
Support configuration for multiple environments (prod/dev) | Multiple template types supported: Production Content, Production Settings, Development Settings
Help ensure that new content (e.g., playbooks) is not missed | Manual review/editing ensures new modules or playbooks are added when needed

</span>